### PR TITLE
Adds chrony_ntp_pools

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,6 +62,23 @@ chrony_logdir: /var/log/chrony
 chrony_maxupdateskew: 100.0
 
 # Define upstream NTP servers
+#
+# Format is a list of dictionaries with the following keys:
+# server:  host or pool
+# type:    (Optional) Defaults to server. Maps to a time source in the
+#           configuration file. Can be one of server, peer, pool.
+# options: (Optional) List of options that depends on type, see Chrony
+#          documentation for details.
+# See: https://chrony.tuxfamily.org/doc/4.0/chrony.conf.html
+#
+# Example of configuring a pool and customising the pool specific maxsources option:
+# chrony_ntp_servers:
+#   - server: pool.ntp.org
+#     type: pool
+#     options:
+#       - option: maxsources
+#         val: 3
+#
 chrony_ntp_servers:
   - server: 0.debian.pool.ntp.org
     options:

--- a/templates/etc/chrony/chrony.conf.j2
+++ b/templates/etc/chrony/chrony.conf.j2
@@ -14,9 +14,9 @@ maxupdateskew {{ chrony_maxupdateskew }}
 rtconutc
 {% for item in chrony_ntp_servers %}
 {%   if item['options'] is not defined %}
-server {{ item['server'] }}
+{{ item['type'] | default('server') }} {{ item['server'] }}
 {%   elif item['options'] is defined %}
-server {{ item['server'] }}{% for opt in item['options'] %} {{ opt['option'] }}{% if opt['val'] is defined %} {{ opt['val'] }}{% endif %}{% endfor %}
+{{ item['type'] | default('server') }} {{ item['server'] }}{% for opt in item['options'] %} {{ opt['option'] }}{% if opt['val'] is defined %} {{ opt['val'] }}{% endif %}{% endfor %}
 
 {%   endif %}
 {% endfor %}


### PR DESCRIPTION
This is useful if you want to use a pool of servers.

The configuration format is identical to chrony_ntp_servers.

See: https://chrony.tuxfamily.org/doc/4.0/chrony.conf.html