### PR TITLE
Use unprivileged containers

### DIFF
--- a/molecule/centos7/molecule.yml
+++ b/molecule/centos7/molecule.yml
@@ -13,11 +13,11 @@ lint: |
 platforms:
   - name: centos7
     image: jrei/systemd-centos:7
-    privileged: true
     command: /usr/sbin/init
-    # tmpfs:
-    #   - /run
-    #   - /tmp
+    tmpfs:
+     - /run
+     - /tmp
+     - /var/run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 provisioner:

--- a/molecule/centos8/molecule.yml
+++ b/molecule/centos8/molecule.yml
@@ -13,11 +13,11 @@ lint: |
 platforms:
   - name: centos8
     image: jrei/systemd-centos:8
-    privileged: true
     command: /usr/sbin/init
-    # tmpfs:
-    #   - /run
-    #   - /tmp
+    tmpfs:
+     - /run
+     - /tmp
+     - /var/run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 provisioner:

--- a/molecule/fedora/molecule.yml
+++ b/molecule/fedora/molecule.yml
@@ -13,11 +13,11 @@ lint: |
 platforms:
   - name: fedora
     image: jrei/systemd-fedora
-    privileged: true
     command: /usr/sbin/init
-    # tmpfs:
-    #   - /run
-    #   - /tmp
+    tmpfs:
+     - /run
+     - /tmp
+     - /var/run
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
 provisioner:


### PR DESCRIPTION
    "stdout": "-- Logs begin at Wed 2021-04-21 18:11:13 UTC, end at Wed 2021-04-21 18:11:54 UTC. --\nApr 21 18:11:53 centos7 systemd[1]: Starting NTP client/server...\nApr 21 18:11:53 centos7 chronyd[525]: chronyd version 3.4 starting (+CMDMON +NTP +REFCLOCK +RTC +PRIVDROP +SCFILTER +SIGND +ASYNCDNS +SECHASH +IPV6 +DEBUG)\nApr 21 18:11:53 centos7 chronyd[525]: commandkey directive is no longer supported\nApr 21 18:11:53 centos7 chronyd[525]: Fatal error : Could not open /var/run/chrony/chronyd.pid : Permission denied\nApr 21 18:11:53 centos7 chronyd[523]: Could not open /var/run/chrony/chronyd.pid : Permission denied\nApr 21 18:11:53 centos7 systemd[1]: chronyd.service: control process exited, code=exited status=1\nApr 21 18:11:53 centos7 systemd[1]: Failed to start NTP client/server.\nApr 21 18:11:53 centos7 systemd[1]: Unit chronyd.service entered failed state.\nApr 21 18:11:53 centos7 systemd[1]: chronyd.service failed.",

E.g: https://github.com/mrlesmithjr/ansible-chrony/pull/10/checks?check_run_id=2403119237#step:5:1795

Alternative to #10 without so many changes.