### PR TITLE
Use fully qualified role name

### DIFF
--- a/molecule/shared/converge.yml
+++ b/molecule/shared/converge.yml
@@ -2,6 +2,6 @@
 - name: Converge
   hosts: all
   tasks:
-    - name: Include ansible-chrony
+    - name: Include mrlesmithjr.chrony
       include_role:
         name: mrlesmithjr.chrony

--- a/molecule/shared/converge.yml
+++ b/molecule/shared/converge.yml
@@ -4,4 +4,4 @@
   tasks:
     - name: Include ansible-chrony
       include_role:
-        name: ansible-chrony
+        name: mrlesmithjr.chrony


### PR DESCRIPTION
Fixes an Issue with CI.
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
It seems that the repository was renamed from ansible-chrony to ansible_chrony and this broke CI. Using the full qualified name should resolve this.
## Related Issue
See: https://github.com/mrlesmithjr/ansible_chrony/runs/2518133095
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
