### PR TITLE
Use import_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # tasks file for ansible-chrony
-- include_tasks: set_facts.yml
+- import_tasks: set_facts.yml
 
 - name: Install Chrony
   package:
@@ -8,4 +8,4 @@
     state: present
   become: true
 
-- include_tasks: config_chrony.yml
+- import_tasks: config_chrony.yml


### PR DESCRIPTION
## Description
include_tasks is dynamic, and incurs some runtime overhead. In contrast,
import_tasks is static. This change switches unconditional task includes
to task imports.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
