### PR TITLE
Use ansible_facts to reference facts

### DIFF
--- a/molecule/shared/prepare.yml
+++ b/molecule/shared/prepare.yml
@@ -5,4 +5,4 @@
       apt:
         update_cache: true
       become: true
-      when: ansible_os_family == "Debian"
+      when: ansible_facts.os_family == "Debian"

--- a/tasks/set_facts.yml
+++ b/tasks/set_facts.yml
@@ -3,10 +3,10 @@
   set_fact:
     chrony_config: /etc/chrony/chrony.conf
     chrony_service: chrony
-  when: ansible_os_family == "Debian"
+  when: ansible_facts.os_family == "Debian"
 
 - name: set_facts | Define RedHat Facts
   set_fact:
     chrony_config: /etc/chrony.conf
     chrony_service: chronyd
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts.os_family == "RedHat"


### PR DESCRIPTION
## Description
By default, Ansible injects a variable for every fact, prefixed with
ansible_. This can result in a large number of variables for each host,
which at scale can incur a performance penalty. Ansible provides a
configuration option [0] that can be set to False to prevent this
injection of facts. In this case, facts should be referenced via
ansible_facts.<fact>.

This change updates all references to Ansible facts from using
individual fact variables to using the items in the
ansible_facts dictionary. This allows users to disable fact variable
injection in their Ansible configuration, which may provide some
performance improvement.

[0] https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
