### PR TITLE
Enables rtcsync by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -100,3 +100,6 @@ chrony_ntp_servers:
       - option: iburst
       - option: minpoll
         val: 8
+
+# Flag to control if the real time clock is to be kept synchronized.
+chrony_rtcsync_enabled: true

--- a/templates/etc/chrony/chrony.conf.j2
+++ b/templates/etc/chrony/chrony.conf.j2
@@ -12,6 +12,9 @@ logchange 0.5
 logdir {{ chrony_logdir }}
 maxupdateskew {{ chrony_maxupdateskew }}
 rtconutc
+{% if chrony_rtcsync_enabled | bool %}
+rtcsync
+{% endif %}
 {% for item in chrony_ntp_servers %}
 {%   if item['options'] is not defined %}
 {{ item['type'] | default('server') }} {{ item['server'] }}


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Keeps the hardware clock synchronized with the NTP server. This seems to be the default in many distributions, for example [here](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-configuring_ntp_using_the_chrony_suite#sect-Understanding_the_chrony_configuration_commands).

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
#23 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
