### PR TITLE
Use ansible_facts to access pkg_mgr

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
     name: chrony
     state: present
     update_cache: yes
-    cache_valid_time: "{{ '3600' if ansible_pkg_mgr == 'apt' else omit }}"
+    cache_valid_time: "{{ '3600' if ansible_facts.pkg_mgr == 'apt' else omit }}"
   become: true
 
 - import_tasks: config_chrony.yml


### PR DESCRIPTION
## Description

This is required when injecting facts as vars is disabled [0].

[0] https://docs.ansible.com/ansible/latest/reference_appendices/config.html#inject-facts-as-vars

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.