### PR TITLE
Allow local stratum to be skipped

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,8 @@ chrony_dumpdir: /var/lib/chrony
 # of a high value like 10 for the local command prevents the machine’s own time
 # from ever being confused with real time, were it ever to leak out to clients
 # that have visibility of real servers.
+#
+# N.B. this value can be set to null, which results in the `local stratum` option being omitted entirely
 chrony_local_stratum: 10
 
 # The log command indicates that certain information is to be logged. It

--- a/templates/etc/chrony/chrony.conf.j2
+++ b/templates/etc/chrony/chrony.conf.j2
@@ -6,7 +6,9 @@ driftfile /var/lib/chrony/chrony.drift
 dumpdir {{ chrony_dumpdir }}
 dumponexit
 keyfile /etc/chrony/chrony.keys
+{% if chrony_local_stratum | bool | default(false) %}
 local stratum {{ chrony_local_stratum }}
+{% endif %}
 log {{ chrony_log|join(' ') }}
 logchange 0.5
 logdir {{ chrony_logdir }}


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Skip `local stratum` directive if desired.
In some cases it's undesirable to advertise the local clock as a reliable time source, especially when operating as an NTP client and not a server. See [Prometheus node exporter](https://github.com/prometheus/node_exporter/blob/master/docs/TIME.md) for example.

## Related Issue
See https://github.com/mrlesmithjr/ansible-chrony/issues/34
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. (there only seems to be a placeholder test at the moment, also see below)
- [ ] All new and existing tests passed. (these didn't seem to be passing on HEAD anyway)
