### PR TITLE
makestep option added - used for VM management

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,12 +1,11 @@
----
 # defaults file for ansible-chrony
 
 # Optionally specify a host, subnet, or network from which to allow NTP
 # connections to a machine acting as NTP server
 chrony_allow_hosts:
-  - 10/8
-  - 192.168/16
-  - 172.16/12
+- 10/8
+- 192.168/16
+- 172.16/12
 
 # Path to the directory to save the measurement history across restarts of
 # chronyd (assuming no changes are made to the system clock behavior whilst
@@ -49,9 +48,9 @@ chrony_local_stratum: 10
 # This option logs the temperature measurements and system rate compensations
 # to a file called tempcomp.log.
 chrony_log:
-  - tracking
-  - measurements
-  - statistics
+- tracking
+- measurements
+- statistics
 
 # This directive allows the directory where log files are written to be specified
 chrony_logdir: /var/log/chrony
@@ -62,6 +61,29 @@ chrony_logdir: /var/log/chrony
 # Typical values for skew-in-ppm might be 100 for a dial-up connection to
 # servers over a telephone line, and 5 or 10 for a computer on a LAN
 chrony_maxupdateskew: 100.0
+
+# maxstep (see https://chrony.tuxfamily.org/doc/4.0/chrony.conf.html#makestep)
+# Normally chronyd will cause the system to gradually correct any time offset,
+# by slowing down or speeding up the clock as required.
+# In certain situations, the system clock might be so far adrift that this
+# slewing process would take a very long time to correct the system clock.
+# This directive forces chronyd to step the system clock if the adjustment
+# is larger than a threshold value, but only if there were no more clock
+# updates since chronyd was started than a specified limit (a negative value
+# can be used to disable the limit).
+# This is particularly useful when using reference clocks, because the
+# initstepslew directive works only with NTP sources.
+# An example of the use of this directive is:
+#
+# chrony_makestep: {threshold: 0.1 3}
+#
+# Sometimes - e.g. on virtual machines, that can be suspended
+# and resumed - you may want to let chronyd step the clock on any update,
+# not just the first ones after it starts:
+# (see https://unix.stackexchange.com/a/484474)
+#
+# chrony_makestep: {threshold: 1, limit: -1}
+
 
 # Define upstream NTP servers
 #
@@ -82,26 +104,26 @@ chrony_maxupdateskew: 100.0
 #         val: 3
 #
 chrony_ntp_servers:
-  - server: 0.debian.pool.ntp.org
-    options:
-      - option: iburst
-      - option: minpoll
-        val: 8
-  - server: 1.debian.pool.ntp.org
-    options:
-      - option: iburst
-      - option: minpoll
-        val: 8
-  - server: 2.debian.pool.ntp.org
-    options:
-      - option: iburst
-      - option: minpoll
-        val: 8
-  - server: 3.debian.pool.ntp.org
-    options:
-      - option: iburst
-      - option: minpoll
-        val: 8
+- server: 0.debian.pool.ntp.org
+  options:
+  - option: iburst
+  - option: minpoll
+    val: 8
+- server: 1.debian.pool.ntp.org
+  options:
+  - option: iburst
+  - option: minpoll
+    val: 8
+- server: 2.debian.pool.ntp.org
+  options:
+  - option: iburst
+  - option: minpoll
+    val: 8
+- server: 3.debian.pool.ntp.org
+  options:
+  - option: iburst
+  - option: minpoll
+    val: 8
 
 # Flag to control if the real time clock is to be kept synchronized.
 chrony_rtcsync_enabled: true

--- a/templates/etc/chrony/chrony.conf.j2
+++ b/templates/etc/chrony/chrony.conf.j2
@@ -14,6 +14,9 @@ logchange 0.5
 logdir {{ chrony_logdir }}
 maxupdateskew {{ chrony_maxupdateskew }}
 rtconutc
+{% if chrony_makestep is defined %}
+makestep {{ chrony_makestep.threshold }} {{ chrony_makestep.limit }}
+{% endif %}
 {% if chrony_rtcsync_enabled | bool %}
 rtcsync
 {% endif %}


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
I have included the makestep option in order to help in vm management, where the time (after snapshot / restore) often 
differs from the actual time by a large margin.


To quote from the docs:

> This directive forces chronyd to step the system clock if the adjustment is larger than a threshold value

Current implementation:

If the variable `chrony_makestep` is defined (e.g. `chrony_makestep: {threshold: 1, limit: -1}`), the relevant entry will be added to the configuration file via the `chrony.conf.j2` template.

`{% if chrony_makestep is defined %}`
`makestep {{ chrony_makestep.threshold }} {{ chrony_makestep.limit }}`
`{% endif %}`

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Please let me know if acceptable and/or if there are any changes needed