### PR TITLE
Remove commandkey directive from configuration

### DIFF
--- a/templates/etc/chrony/chrony.conf.j2
+++ b/templates/etc/chrony/chrony.conf.j2
@@ -1,7 +1,6 @@
 {% for item in chrony_allow_hosts %}
 allow {{ item }}
 {% endfor %}
-commandkey 1
 driftfile /var/lib/chrony/chrony.drift
 dumpdir {{ chrony_dumpdir }}
 dumponexit


### PR DESCRIPTION
The commandkey directive was removed in version 2.2 [1] which was released in October 2015. This will silence:

    commandkey directive is no longer supported

[1] https://chrony.tuxfamily.org/faq.html#_what_happened_to_the_commandkey_and_generatecommandkey_directives

## Related Issue

Fixes #41 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking cwhange that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
