### PR TITLE
Fix Jinja conditional

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,8 @@ chrony_dumpdir: /var/lib/chrony
 # from ever being confused with real time, were it ever to leak out to clients
 # that have visibility of real servers.
 #
-# N.B. this value can be set to null, which results in the `local stratum` option being omitted entirely
+# N.B. this value can be set to null or 0, which results in the `local stratum`
+# option being omitted entirely.
 chrony_local_stratum: 10
 
 # The log command indicates that certain information is to be logged. It

--- a/templates/etc/chrony/chrony.conf.j2
+++ b/templates/etc/chrony/chrony.conf.j2
@@ -5,7 +5,7 @@ driftfile /var/lib/chrony/chrony.drift
 dumpdir {{ chrony_dumpdir }}
 dumponexit
 keyfile /etc/chrony/chrony.keys
-{% if chrony_local_stratum | bool | default(false) %}
+{% if chrony_local_stratum is defined and chrony_local_stratum | int > 0 %}
 local stratum {{ chrony_local_stratum }}
 {% endif %}
 log {{ chrony_log|join(' ') }}


### PR DESCRIPTION
## Description

A change to the bool filter [1] is impacting generated configuration. Before ansible-core 2.19, `chrony_local_stratum | bool` would evaluate to true with the default value of `chrony_local_stratum: 10`. Now it evaluates to false:

    [DEPRECATION WARNING]: The `bool` filter coerced invalid value 10
    (int) to False. This feature will be removed from ansible-core
    version 2.23.

[1] https://github.com/ansible-community/ansible-build-data/blob/main/12/CHANGELOG-v12.md#ansible-core-9

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
