### PR TITLE
feat: add configurable makestep support with safe defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -106,3 +106,21 @@ chrony_ntp_servers:
 
 # Flag to control if the real time clock is to be kept synchronized.
 chrony_rtcsync_enabled: true
+
+# The makestep directive tells chronyd to step the system clock if the time
+# error is larger than the threshold value, but only during the first number
+# of updates. After that, it will slew. A threshold of 0.001 means that if the
+# error is larger than 1 millisecond but smaller than 1 second, chronyd will
+# slew the clock. A threshold of 1.0 means that if the error is larger than 1
+# second, chronyd will step the clock.
+#
+# This is particularly useful for virtual machines, where the time can drift
+# significantly during suspend/resume cycles or host time changes.
+#
+# Format:
+# makestep <threshold> <attempts>
+# threshold: seconds (float)
+# attempts:  number of updates (int, -1 for unlimited)
+chrony_makestep_enabled: false
+chrony_makestep_threshold: 1.0
+chrony_makestep_attempts: 3

--- a/molecule/shared/verify.yml
+++ b/molecule/shared/verify.yml
@@ -1,9 +1,27 @@
 ---
-# This is an example playbook to execute Ansible tests.
-
 - name: Verify
   hosts: all
   tasks:
-  - name: Example assertion
-    ansible.builtin.assert:
-      that: true
+    - name: Get chrony config path
+      ansible.builtin.set_fact:
+        chrony_config_path: "{{ '/etc/chrony/chrony.conf' if ansible_facts.os_family == 'Debian' else '/etc/chrony.conf' }}"
+
+    - name: Check if makestep line is present in config
+      ansible.builtin.lineinfile:
+        path: "{{ chrony_config_path }}"
+        regexp: '^makestep'
+        state: absent
+      check_mode: true
+      register: makestep_check
+
+    - name: Assert makestep is absent when disabled (default)
+      ansible.builtin.assert:
+        that: not makestep_check.changed
+        fail_msg: "makestep line should not be present when chrony_makestep_enabled is false (default)"
+      when: not (chrony_makestep_enabled | default(false) | bool)
+
+    - name: Assert makestep is present when enabled
+      ansible.builtin.assert:
+        that: makestep_check.changed
+        fail_msg: "makestep line not found in chrony.conf when chrony_makestep_enabled is true"
+      when: chrony_makestep_enabled | default(false) | bool

--- a/templates/etc/chrony/chrony.conf.j2
+++ b/templates/etc/chrony/chrony.conf.j2
@@ -2,6 +2,9 @@
 allow {{ item }}
 {% endfor %}
 driftfile /var/lib/chrony/chrony.drift
+{% if chrony_makestep_enabled | bool %}
+makestep {{ chrony_makestep_threshold }} {{ chrony_makestep_attempts }}
+{% endif %}
 dumpdir {{ chrony_dumpdir }}
 dumponexit
 keyfile /etc/chrony/chrony.keys


### PR DESCRIPTION
## Description
Adds configurable `makestep` support for quick initial clock corrections (ideal for VMs/Proxmox).  
- Safe defaults: `enabled: false`, `threshold: 1.0`, `attempts: 3`.  
- Style/docs aligned with existing

## Related Issue
N/A (new feature request)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.